### PR TITLE
Fix depends to use auth literal

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -14,7 +14,7 @@
   "auth": "github:gabrielash",
 
   "depends": [
-    "Net::ZMQ:auth('github:gabrielash')",
+    "Net::ZMQ:auth<github:gabrielash>",
     "JSON::Tiny"
   ],
   "tags": [


### PR DESCRIPTION
zef will not evaluate code to determine these fields, or else someone could`Foo:auth(shell "rm -rf /")`